### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/release_check.py
+++ b/release_check.py
@@ -3,7 +3,7 @@
 import sys
 
 props = {}
-for line in open('android/properties/private-%s.properties' % sys.argv[-1]):
+for line in open('android/properties/private-{0!s}.properties'.format(sys.argv[-1])):
     if len(line.strip()) == 0:
         continue
     if line[0] == '#':


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:MozStumbler?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:MozStumbler?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
